### PR TITLE
use unique_basisfn

### DIFF
--- a/Sources/ParameterSpaces/b_spline_basis_function.hpp
+++ b/Sources/ParameterSpaces/b_spline_basis_function.hpp
@@ -35,6 +35,25 @@ template<int parametric_dimensionality>
 using UniqueBSplineBasisFunctionsArray =
     Array<UniqueBSplineBasisFunctions, parametric_dimensionality>;
 
+// it is just a holder to lookup
+using UniqueEvaluations = Vector<ParametricCoordinate::Type_>;
+// turns out they both can have the same type.
+using UniqueDerivatives = UniqueEvaluations;
+
+template<int parametric_dimensionality>
+using UniqueEvaluationsArray =
+    Array<UniqueEvaluations, parametric_dimensionality>;
+
+template<int parametric_dimensionality>
+using UniqueDerivativesArray =
+    Array<UniqueDerivatives, parametric_dimensionality>;
+
+using IsTopLevelComputed = Vector<bool>;
+
+template<int parametric_dimensionality>
+using IsTopLevelComputedArray = Array<IsTopLevelComputed,
+                                      parametric_dimensionality>;
+
 // BSplineBasisFunctions N_{i,p} are non-negative, piecewise polynomial functions of degree p forming a basis of the
 // vector space of all piecewise polynomial functions of degree p corresponding to some knot vector.  The B-spline basis
 // functions have local support only and form a partition of unity.  Actual implementations for evaluating them (as well
@@ -71,9 +90,27 @@ class BSplineBasisFunction {
   friend bool IsEqual(BSplineBasisFunction const &lhs, BSplineBasisFunction const &rhs, Tolerance const &tolerance);
   // Comparison based on numeric_operations::GetEpsilon<Tolerance>().
   friend bool operator==(BSplineBasisFunction const &lhs, BSplineBasisFunction const &rhs);
-  virtual Type_ operator()(ParametricCoordinate const &parametric_coordinate, Tolerance const &tolerance = kEpsilon)
-      const = 0;
-  virtual Type_ operator()(ParametricCoordinate const &parametric_coordinate, Derivative const &derivative,
+  virtual Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                           Tolerance const &tolerance = kEpsilon) const = 0;
+  // tree_info should tell you if requested basis function is ...
+  //   <tree_info value> : <info>
+  //                  -2 : left branch
+  //                  -1 : right branch
+  //         0 or bigger : top_node id. used to determine entry id for
+  //                       top level evaluations
+  virtual Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                           UniqueEvaluations& unique_evaluations,
+                           int const &tree_info,
+                           Tolerance const &tolerance = kEpsilon) const = 0;
+  virtual Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                           Derivative const &derivative,
+                           Tolerance const &tolerance = kEpsilon) const = 0;
+  virtual Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                           Derivative const &derivative,
+                           UniqueDerivatives& unique_derivatives,
+                           UniqueEvaluations& unique_evaluations,
+                           IsTopLevelComputed& top_level_computed,
+                           int const &tree_info,
                            Tolerance const &tolerance = kEpsilon) const = 0;
 
  protected:

--- a/Sources/ParameterSpaces/b_spline_basis_function.hpp
+++ b/Sources/ParameterSpaces/b_spline_basis_function.hpp
@@ -19,8 +19,21 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #include "Sources/ParameterSpaces/knot_vector.hpp"
 #include "Sources/Utilities/named_type.hpp"
 #include "Sources/Utilities/std_container_operations.hpp"
+#include "Sources/Utilities/string_operations.hpp" // for String alias.
 
 namespace splinelib::sources::parameter_spaces {
+
+class BSplineBasisFunction;
+
+// proof of concept
+// unorderd_map key syntax
+// <start_of_support>_<degree>
+using UniqueBSplineBasisFunctions =
+    UnorderedMap<String, SharedPointer<BSplineBasisFunction>>;
+
+template<int parametric_dimensionality>
+using UniqueBSplineBasisFunctionsArray =
+    Array<UniqueBSplineBasisFunctions, parametric_dimensionality>;
 
 // BSplineBasisFunctions N_{i,p} are non-negative, piecewise polynomial functions of degree p forming a basis of the
 // vector space of all piecewise polynomial functions of degree p corresponding to some knot vector.  The B-spline basis
@@ -39,8 +52,18 @@ class BSplineBasisFunction {
  public:
   using Type_ = ParametricCoordinate::Type_;
 
-  static BSplineBasisFunction * CreateDynamic(KnotVector const &knot_vector, KnotSpan const &start_of_support,
-      Degree degree, Tolerance const &tolerance = kEpsilon);
+  static BSplineBasisFunction * CreateDynamic(
+      KnotVector const &knot_vector,
+      KnotSpan const &start_of_support,
+      Degree degree,
+      Tolerance const &tolerance = kEpsilon);
+
+  static SharedPointer<BSplineBasisFunction> CreateDynamic(
+      KnotVector const &knot_vector,
+      KnotSpan const &start_of_support,
+      Degree degree,
+      UniqueBSplineBasisFunctions &unique_basis_functions,
+      Tolerance const &tolerance = kEpsilon);
 
   virtual ~BSplineBasisFunction() = default;
 

--- a/Sources/ParameterSpaces/non_zero_degree_b_spline_basis_function.cpp
+++ b/Sources/ParameterSpaces/non_zero_degree_b_spline_basis_function.cpp
@@ -101,8 +101,9 @@ bool operator==(NonZeroDegreeBSplineBasisFunction const &lhs, NonZeroDegreeBSpli
 
 // Recurrence formula due to DeBoor, Cox, and Mansfield (see NURBS book Eq. (2.5)).
 NonZeroDegreeBSplineBasisFunction::Type_
-NonZeroDegreeBSplineBasisFunction::operator()(ParametricCoordinate const &parametric_coordinate,
-                                              Tolerance const &tolerance) const {
+NonZeroDegreeBSplineBasisFunction::operator()(
+    ParametricCoordinate const &parametric_coordinate,
+    Tolerance const &tolerance) const {
 #ifndef NDEBUG
   try {
     utilities::numeric_operations::ThrowIfToleranceIsNegative(tolerance);
@@ -110,10 +111,70 @@ NonZeroDegreeBSplineBasisFunction::operator()(ParametricCoordinate const &parame
     Throw(exception, "splinelib::sources::parameter_spaces::NonZeroDegreeBSplineBasisFunction::operator()");
   }
 #endif
-  return IsInSupport(parametric_coordinate, tolerance) ? (((parametric_coordinate - start_knot_).Get() *
-      left_denominator_inverse_ * (*left_lower_degree_basis_function_)(parametric_coordinate, tolerance)) +
-          ((end_knot_ - parametric_coordinate).Get() * right_denominator_inverse_ *
-           (*right_lower_degree_basis_function_)(parametric_coordinate, tolerance))) : Type_{};
+  return IsInSupport(parametric_coordinate, tolerance) ? (
+      ((parametric_coordinate - start_knot_).Get()
+        * left_denominator_inverse_
+        * (*left_lower_degree_basis_function_)(parametric_coordinate,
+                                               tolerance))
+       + ((end_knot_
+           - parametric_coordinate).Get()
+           * right_denominator_inverse_
+           * (*right_lower_degree_basis_function_)(parametric_coordinate,
+                                                   tolerance))
+  ) : Type_{};
+}
+
+NonZeroDegreeBSplineBasisFunction::Type_
+NonZeroDegreeBSplineBasisFunction::operator()(
+    ParametricCoordinate const &parametric_coordinate,
+    UniqueEvaluations& unique_evaluations,
+    int const &tree_info,
+    Tolerance const &tolerance) const {
+
+  // First, support check - exit if not
+  if (!IsInSupport(parametric_coordinate, tolerance)) {
+    return Type_{};
+  }
+
+  int entry_offset{};
+  const auto& id = degree_.Get();
+  // evaluation is quite deterministic: it is clear when to lookup
+  if (tree_info == -2) {
+    // lucky, just take a look.
+    // this is valid for all left branches.
+    return unique_evaluations[id];
+
+  } else if (tree_info >= 0) {
+    // indicates this is top-level nodes
+    // check if this has been computed
+    const auto& top_level_evaluation = unique_evaluations[id + tree_info];
+    // values are initialized with negative value and if computed,
+    // it should be non-negative.
+    if (top_level_evaluation >= 0.0) {
+       return top_level_evaluation;
+    }
+
+    entry_offset = tree_info;
+  }
+  // it is your duty to compute.
+  // this means you are either at the top-level node or right branch.
+  auto& computed_basis = unique_evaluations[id + entry_offset];
+  computed_basis =
+      ((parametric_coordinate - start_knot_).Get()
+        * left_denominator_inverse_
+        * (*left_lower_degree_basis_function_)(parametric_coordinate,
+                                               unique_evaluations,
+                                               -2,
+                                               tolerance))
+      + ((end_knot_ - parametric_coordinate).Get()
+          * right_denominator_inverse_
+          * (*right_lower_degree_basis_function_)(parametric_coordinate,
+                                                  unique_evaluations,
+                                                  -1,
+                                                  tolerance));
+
+  return computed_basis;
+
 }
 
 // Based on recurrence formula due to DeBoor, Cox, and Mansfield (see NURBS book Eq. (2.9)).
@@ -130,9 +191,16 @@ NonZeroDegreeBSplineBasisFunction::operator()(ParametricCoordinate const &parame
   if (derivative != Derivative{}) {
     if (IsInSupport(parametric_coordinate, tolerance)) {
       Derivative const lower_derivative = (derivative - Derivative{1});
-      return ((left_quotient_derivative_ * (*left_lower_degree_basis_function_)(parametric_coordinate, lower_derivative,
-                   tolerance)) - (right_quotient_derivative_ *
-                       (*right_lower_degree_basis_function_)(parametric_coordinate, lower_derivative, tolerance)));
+      return (
+          (left_quotient_derivative_
+           * (*left_lower_degree_basis_function_)(parametric_coordinate,
+                                                  lower_derivative,
+                                                  tolerance))
+          - (right_quotient_derivative_ 
+             * (*right_lower_degree_basis_function_)(parametric_coordinate,
+                                                     lower_derivative,
+                                                     tolerance))
+      );
     } else {
       return Type_{};
     }
@@ -140,6 +208,111 @@ NonZeroDegreeBSplineBasisFunction::operator()(ParametricCoordinate const &parame
     return operator()(parametric_coordinate, tolerance);
   }
 }
+
+NonZeroDegreeBSplineBasisFunction::Type_
+NonZeroDegreeBSplineBasisFunction::operator()(
+    ParametricCoordinate const &parametric_coordinate,
+    Derivative const &derivative,
+    UniqueDerivatives& unique_derivatives,
+    UniqueEvaluations& unique_evaluations,
+    IsTopLevelComputed& top_level_computed,
+    int const &tree_info,
+    Tolerance const &tolerance) const {
+#ifndef NDEBUG
+  try {
+    utilities::numeric_operations::ThrowIfToleranceIsNegative(tolerance);
+  } catch (InvalidArgument const &exception) {
+    Throw(exception, "splinelib::sources::parameter_spaces::NonZeroDegreeBSplineBasisFunction::operator()");
+  }
+#endif
+
+  int entry_offset{}; /* will be zero, unless it is top-level node */
+  if (tree_info == -2) {
+    return unique_derivatives[derivative.Get()];
+
+  } else if (tree_info >= 0) {
+    // indicates this is top-level nodes.
+    // check if this has been computed
+    //
+    // for derivatives, there are no simple rule that tells us if
+    // it was evaluated.
+    // so, we look at an additional info
+    if (top_level_computed[tree_info]) {
+        // for 0-th derivative, look at evaluations. 
+        if (derivative == Derivative{}) {
+          throw std::runtime_error(
+            String("CRITICAL ISSUE! Please help us by writing an issue at ")
+            + String("github.com/tataratat/SplineLib")
+          );
+        }
+        return unique_derivatives[derivative.Get() + tree_info];
+    }
+
+    // save tree_info to place freshly computed value at the right place.
+    entry_offset = tree_info;
+
+    // we are here, because it wasn't computed and in following parts,
+    // it will be computed.
+    // warning: premature action.
+    // an alternative would be checking if entry_offset is >= 0 then set true.
+    top_level_computed[tree_info] = true;
+  }
+
+  // it is your duty to compute
+  // top-level-degree derivatives and all right_lower ones.
+  if (derivative != Derivative{}) {
+      if (!IsInSupport(parametric_coordinate, tolerance)) {
+        // tschuess
+        return Type_{};
+      }
+
+    Derivative const lower_derivative = (derivative - Derivative{1});
+    // same idea as evaluation.
+    // top-level-derivative and all right ones
+    auto& computed_basis = unique_derivatives[derivative.Get() + entry_offset];
+    computed_basis = 
+        (left_quotient_derivative_
+         * (*left_lower_degree_basis_function_)(parametric_coordinate,
+                                                lower_derivative,
+                                                unique_derivatives,
+                                                unique_evaluations,
+                                                top_level_computed,
+                                                -2,
+                                                tolerance))
+        - (right_quotient_derivative_
+           * (*right_lower_degree_basis_function_)(parametric_coordinate,
+                                                   lower_derivative,
+                                                   unique_derivatives,
+                                                   unique_evaluations,
+                                                   top_level_computed,
+                                                   -1,
+                                                   tolerance));
+
+      // here would be a good alternative place to set top-level computed flag.
+      return computed_basis;
+
+  } else {
+    // zeroth derivative evaluation. same as normal evaluation.
+    // treat it as normal evaluation <- need top level node info.
+    // could use an additional input if this takes too long.
+    int top_level_id{-1};
+    // compiler told me `bool` will be copied anyways. Hence, no auto&
+    for (const auto computed : top_level_computed) {
+      if(!computed) break;
+      ++top_level_id;
+    }
+    const auto evaluation = operator()(parametric_coordinate,
+                                       unique_evaluations,
+                                       top_level_id,
+                                       tolerance);
+
+    // Here's always 0th derivative.
+    unique_derivatives[0] = evaluation;
+
+    return evaluation;
+  }
+}
+
 
 NonZeroDegreeBSplineBasisFunction::Type_
 NonZeroDegreeBSplineBasisFunction::InvertPotentialZero(ParametricCoordinate const &potential_zero,

--- a/Sources/ParameterSpaces/non_zero_degree_b_spline_basis_function.cpp
+++ b/Sources/ParameterSpaces/non_zero_degree_b_spline_basis_function.cpp
@@ -37,6 +37,43 @@ NonZeroDegreeBSplineBasisFunction::NonZeroDegreeBSplineBasisFunction(KnotVector 
     right_quotient_derivative_ = (degree_value * right_denominator_inverse_);
 }
 
+NonZeroDegreeBSplineBasisFunction::NonZeroDegreeBSplineBasisFunction(
+    KnotVector const &knot_vector,
+    KnotSpan const &start_of_support,
+    Degree degree,
+    UniqueBSplineBasisFunctions &unique_basis_functions,
+    Tolerance const &tolerance)
+        : Base_(knot_vector, /* generates this_hash_ */
+                start_of_support,
+                std::move(degree),
+                tolerance),
+          left_lower_degree_basis_function_{
+              CreateDynamic(knot_vector,
+                            start_of_support,
+                            degree_ - Degree{1},
+                            unique_basis_functions,
+                            tolerance)},
+          right_lower_degree_basis_function_{
+              CreateDynamic(knot_vector,
+                            start_of_support + KnotSpan{1},
+                            degree_ - Degree{1},
+                            unique_basis_functions,
+                            tolerance)}
+{
+    Index const start_index{start_of_support.Get()};
+    Degree::Type_ const &degree_value = degree_.Get();
+    left_denominator_inverse_ = InvertPotentialZero(
+        knot_vector[start_index + Index{degree_value}] - start_knot_,
+        tolerance
+    );
+    right_denominator_inverse_ = InvertPotentialZero(
+        end_knot_ - knot_vector[start_index + Index{1}],
+        tolerance
+    );
+    left_quotient_derivative_ = (degree_value * left_denominator_inverse_);
+    right_quotient_derivative_ = (degree_value * right_denominator_inverse_);
+}
+
 bool IsEqual(NonZeroDegreeBSplineBasisFunction const &lhs, NonZeroDegreeBSplineBasisFunction const &rhs,
              Tolerance const &tolerance) {
   using Base = NonZeroDegreeBSplineBasisFunction::Base_;

--- a/Sources/ParameterSpaces/non_zero_degree_b_spline_basis_function.hpp
+++ b/Sources/ParameterSpaces/non_zero_degree_b_spline_basis_function.hpp
@@ -40,16 +40,30 @@ class NonZeroDegreeBSplineBasisFunction : public virtual BSplineBasisFunction {
   using Type_ = Base_::Type_;
 
   NonZeroDegreeBSplineBasisFunction() = default;
-  NonZeroDegreeBSplineBasisFunction(KnotVector const &knot_vector, KnotSpan const &start_of_support, Degree degree,
-                                    Tolerance const &tolerance = kEpsilon);
-  NonZeroDegreeBSplineBasisFunction(NonZeroDegreeBSplineBasisFunction const &other) = default;
-  NonZeroDegreeBSplineBasisFunction(NonZeroDegreeBSplineBasisFunction &&other) noexcept = default;
-  NonZeroDegreeBSplineBasisFunction & operator=(NonZeroDegreeBSplineBasisFunction const &rhs) = default;
-  NonZeroDegreeBSplineBasisFunction & operator=(NonZeroDegreeBSplineBasisFunction &&rhs) noexcept = default;
+  NonZeroDegreeBSplineBasisFunction(
+      KnotVector const &knot_vector,
+      KnotSpan const &start_of_support,
+      Degree degree,
+      Tolerance const &tolerance = kEpsilon);
+  NonZeroDegreeBSplineBasisFunction(
+      KnotVector const &knot_vector,
+      KnotSpan const &start_of_support,
+      Degree degree,
+      UniqueBSplineBasisFunctions &unique_basis_functions,
+      Tolerance const &tolerance = kEpsilon);
+  NonZeroDegreeBSplineBasisFunction(
+      NonZeroDegreeBSplineBasisFunction const &other) = default;
+  NonZeroDegreeBSplineBasisFunction(
+      NonZeroDegreeBSplineBasisFunction &&other) noexcept = default;
+  NonZeroDegreeBSplineBasisFunction & operator=(
+      NonZeroDegreeBSplineBasisFunction const &rhs) = default;
+  NonZeroDegreeBSplineBasisFunction & operator=(
+      NonZeroDegreeBSplineBasisFunction &&rhs) noexcept = default;
   ~NonZeroDegreeBSplineBasisFunction() override = default;
 
   // Comparison based on tolerance.
-  friend bool IsEqual(NonZeroDegreeBSplineBasisFunction const &lhs, NonZeroDegreeBSplineBasisFunction const &rhs,
+  friend bool IsEqual(NonZeroDegreeBSplineBasisFunction const &lhs,
+                      NonZeroDegreeBSplineBasisFunction const &rhs,
                       Tolerance const &tolerance);
   // Comparison based on numeric_operations::GetEpsilon<Tolerance>().
   friend bool operator==(NonZeroDegreeBSplineBasisFunction const &lhs, NonZeroDegreeBSplineBasisFunction const &rhs);
@@ -59,17 +73,24 @@ class NonZeroDegreeBSplineBasisFunction : public virtual BSplineBasisFunction {
                    Tolerance const &tolerance = kEpsilon) const override;
 
  protected:
-  Type_ left_denominator_inverse_, right_denominator_inverse_, left_quotient_derivative_, right_quotient_derivative_;
+  Type_ left_denominator_inverse_,
+        right_denominator_inverse_,
+        left_quotient_derivative_,
+        right_quotient_derivative_;
   // Shared instead of unique pointers as BSplineBasisFunctions cannot be modified after their construction.
-  SharedPointer<Base_> left_lower_degree_basis_function_, right_lower_degree_basis_function_;
+  SharedPointer<Base_> left_lower_degree_basis_function_,
+                       right_lower_degree_basis_function_;
 
  private:
-  Type_ InvertPotentialZero(ParametricCoordinate const &potential_zero, Tolerance const &tolerance) const;  // 1/0 := 0.
+  Type_ InvertPotentialZero(ParametricCoordinate const &potential_zero,
+                            Tolerance const &tolerance) const;  // 1/0 := 0.
 };
 
-bool IsEqual(NonZeroDegreeBSplineBasisFunction const &lhs, NonZeroDegreeBSplineBasisFunction const &rhs,
+bool IsEqual(NonZeroDegreeBSplineBasisFunction const &lhs,
+             NonZeroDegreeBSplineBasisFunction const &rhs,
              Tolerance const &tolerance = kEpsilon);
-bool operator==(NonZeroDegreeBSplineBasisFunction const &lhs, NonZeroDegreeBSplineBasisFunction const &rhs);
+bool operator==(NonZeroDegreeBSplineBasisFunction const &lhs,
+                NonZeroDegreeBSplineBasisFunction const &rhs);
 
 }  // namespace splinelib::sources::parameter_spaces
 

--- a/Sources/ParameterSpaces/non_zero_degree_b_spline_basis_function.hpp
+++ b/Sources/ParameterSpaces/non_zero_degree_b_spline_basis_function.hpp
@@ -66,10 +66,23 @@ class NonZeroDegreeBSplineBasisFunction : public virtual BSplineBasisFunction {
                       NonZeroDegreeBSplineBasisFunction const &rhs,
                       Tolerance const &tolerance);
   // Comparison based on numeric_operations::GetEpsilon<Tolerance>().
-  friend bool operator==(NonZeroDegreeBSplineBasisFunction const &lhs, NonZeroDegreeBSplineBasisFunction const &rhs);
-  Type_ operator()(ParametricCoordinate const &parametric_coordinate, Tolerance const &tolerance = kEpsilon) const
-      override;
-  Type_ operator()(ParametricCoordinate const &parametric_coordinate, Derivative const &derivative,
+  friend bool operator==(NonZeroDegreeBSplineBasisFunction const &lhs,
+                         NonZeroDegreeBSplineBasisFunction const &rhs);
+  Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                   Tolerance const &tolerance = kEpsilon) const override;
+  Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                   UniqueEvaluations& unique_evaluations,
+                   int const& tree_info,
+                   Tolerance const &tolerance = kEpsilon) const override;
+  Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                   Derivative const &derivative,
+                   Tolerance const &tolerance = kEpsilon) const override;
+  Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                   Derivative const &derivative,
+                   UniqueDerivatives& unique_derivatives,
+                   UniqueEvaluations& unique_evaluations,
+                   IsTopLevelComputed& top_level_computed,
+                   int const &tree_info,
                    Tolerance const &tolerance = kEpsilon) const override;
 
  protected:

--- a/Sources/ParameterSpaces/parameter_space.hpp
+++ b/Sources/ParameterSpaces/parameter_space.hpp
@@ -69,6 +69,10 @@ class ParameterSpace {
 
  protected:
   using BSplineBasisFunctions_ = BSplineBasisFunctions<parametric_dimensionality>;
+  // Not to be confused with parameter_spaces::UniqueBSplineBasisFunctions
+  // Named this way just to be consistent with `BSplineBasisFunctions_`.
+  using UniqueBSplineBasisFunctions_ =
+      UniqueBSplineBasisFunctionsArray<parametric_dimensionality>;
 
  public:
   using BinomialRatios_ = Vector<BinomialRatio>;
@@ -147,11 +151,14 @@ class ParameterSpace {
   virtual const Degrees_& GetDegrees() const {return degrees_;}
   virtual const BSplineBasisFunctions_&
       GetBSplineBasisFunctions() const {return basis_functions_;}
+  virtual const UniqueBSplineBasisFunctions_&
+      GetUniqueBSplineBasisFunctions() const {return unique_basis_functions_;}
 
  protected:
   KnotVectors_ knot_vectors_;
   Degrees_ degrees_;
   BSplineBasisFunctions_ basis_functions_;
+  UniqueBSplineBasisFunctions_ unique_basis_functions_;
 
  private:
   using MultiplicityType_ = Multiplicity::Type_;

--- a/Sources/ParameterSpaces/parameter_space.hpp
+++ b/Sources/ParameterSpaces/parameter_space.hpp
@@ -97,6 +97,11 @@ class ParameterSpace {
   using BezierInformation_ = Tuple<int, Knots_>;
   using Knot_ = typename Knots_::value_type;
 
+  // same reason as UniqueBSplineBasisFunctions_
+  using UniqueEvaluations_ = UniqueEvaluationsArray<parametric_dimensionality>;
+  using UniqueDerivatives_ = UniqueDerivativesArray<parametric_dimensionality>;
+  using IsTopLevelComputed_ = IsTopLevelComputedArray<parametric_dimensionality>;
+
   ParameterSpace() = default;
   ParameterSpace(KnotVectors_ knot_vectors, Degrees_ degrees, Tolerance const &tolerance = kEpsilon);
   ParameterSpace(ParameterSpace const &other);
@@ -120,11 +125,29 @@ class ParameterSpace {
                                                Tolerance const &tolerance = kEpsilon) const;
   virtual BezierInformation_ DetermineBezierExtractionKnots(Dimension const &dimension,
                                                             Tolerance const &tolerance = kEpsilon) const;
-
-  virtual Type_ EvaluateBasisFunction(Index_ const &basis_function_index,
-      ParametricCoordinate_ const &parametric_coordinate, Tolerance const &tolerance = kEpsilon) const;
-  virtual Type_ EvaluateBasisFunctionDerivative(Index_ const &basis_function_index,
-      ParametricCoordinate_ const &parametric_coordinate, Derivative_ const &derivative,
+  virtual Type_ EvaluateBasisFunction(
+      Index_ const &basis_function_index,
+      ParametricCoordinate_ const &parametric_coordinate,
+      Tolerance const &tolerance = kEpsilon) const;
+  virtual Type_ EvaluateBasisFunction(
+      Index_ const &basis_function_index,
+      Index_ const &basis_function_index_without_offset,
+      ParametricCoordinate_ const &parametric_coordinate,
+      UniqueEvaluations_& unique_evaluations,
+      Tolerance const &tolerance = kEpsilon) const;
+  virtual Type_ EvaluateBasisFunctionDerivative(
+      Index_ const &basis_function_index,
+      ParametricCoordinate_ const &parametric_coordinate,
+      Derivative_ const &derivative,
+      Tolerance const &tolerance = kEpsilon) const;
+  virtual Type_ EvaluateBasisFunctionDerivative(
+      Index_ const &basis_function_index,
+      Index_ const &basis_function_index_without_offset,
+      IsTopLevelComputed_& top_level_computed,
+      ParametricCoordinate_ const &parametric_coordinate,
+      Derivative_ const &derivative,
+      UniqueDerivatives_& unique_derivatives,
+      UniqueEvaluations_& unique_evaluations,
       Tolerance const &tolerance = kEpsilon) const;
 
   virtual InsertionInformation_ InsertKnot(Dimension const &dimension, Knot_ knot,

--- a/Sources/ParameterSpaces/parameter_space.inc
+++ b/Sources/ParameterSpaces/parameter_space.inc
@@ -185,6 +185,49 @@ ParameterSpace<parametric_dimensionality>::EvaluateBasisFunction(Index_ const &b
 
 template<int parametric_dimensionality>
 typename ParameterSpace<parametric_dimensionality>::Type_
+ParameterSpace<parametric_dimensionality>::EvaluateBasisFunction(
+    Index_ const &basis_function_index,
+    Index_ const &basis_function_index_without_offset,
+    ParametricCoordinate_ const &parametric_coordinate,
+    UniqueEvaluations_& unique_evaluations,
+    Tolerance const &tolerance) const {
+#ifndef NDEBUG
+  Message const kName{"splinelib::sources::parameter_spaces::ParameterSpace::EvaluateBasisFunction"};
+
+  try {
+    ThrowIfBasisFunctionIndexIsInvalid(basis_function_index);
+    utilities::numeric_operations::ThrowIfToleranceIsNegative(tolerance);
+  } catch (InvalidArgument const &exception) { Throw(exception, kName); }
+    catch (OutOfRange const &exception) { Throw(exception, kName); }
+#endif
+
+
+  Type_ basis_function_value{1.0};
+  Dimension::ForEach(
+      0,
+      parametric_dimensionality,
+      [&] (Dimension const &dimension) {
+        Dimension::Type_ const &current_dimension = dimension.Get();
+
+        // extract the basis function we need
+        const auto& basis_functions =
+            basis_functions_[current_dimension];
+        const auto& basis_function =
+            *basis_functions[basis_function_index[dimension].Get()];
+
+        basis_function_value *= basis_function(
+            parametric_coordinate[current_dimension],
+            unique_evaluations[current_dimension],
+            basis_function_index_without_offset[dimension].Get(),
+            tolerance
+        );
+      }
+  );
+  return basis_function_value;
+}
+
+template<int parametric_dimensionality>
+typename ParameterSpace<parametric_dimensionality>::Type_
 ParameterSpace<parametric_dimensionality>::EvaluateBasisFunctionDerivative(Index_ const &basis_function_index,
     ParametricCoordinate_ const &parametric_coordinate, Derivative_ const &derivative, Tolerance const &tolerance) const
 {
@@ -203,6 +246,64 @@ ParameterSpace<parametric_dimensionality>::EvaluateBasisFunctionDerivative(Index
     basis_function_derivative_value *=
         (*basis_functions_[current_dimension][basis_function_index[dimension].Get()])(
             parametric_coordinate[current_dimension], derivative[current_dimension], tolerance); });
+  return basis_function_derivative_value;
+}
+
+template<int parametric_dimensionality>
+typename ParameterSpace<parametric_dimensionality>::Type_
+ParameterSpace<parametric_dimensionality>::EvaluateBasisFunctionDerivative(
+    Index_ const &basis_function_index,
+    Index_ const &basis_function_index_without_offset,
+    IsTopLevelComputed_ &top_level_computed,
+    ParametricCoordinate_ const &parametric_coordinate,
+    Derivative_ const &derivative,
+    UniqueDerivatives_& unique_derivatives,
+    UniqueEvaluations_& unique_evaluations,
+    Tolerance const &tolerance) const {
+#ifndef NDEBUG
+  Message const kName{"splinelib::sources::parameter_spaces::ParameterSpace::EvaluateBasisFunctionDerivative"};
+
+  try {
+    ThrowIfBasisFunctionIndexIsInvalid(basis_function_index);
+    utilities::numeric_operations::ThrowIfToleranceIsNegative(tolerance);
+  } catch (InvalidArgument const &exception) { Throw(exception, kName); }
+    catch (OutOfRange const &exception) { Throw(exception, kName); }
+#endif
+  Type_ basis_function_derivative_value{1.0};
+  Dimension::ForEach(
+      0,
+      parametric_dimensionality,
+      [&] (Dimension const &dimension) {
+
+        Dimension::Type_ const &current_dimension = dimension.Get();
+        // extract the basis function we need
+        const auto& basis_functions =
+            basis_functions_[current_dimension];
+        const auto& basis_function =
+            *basis_functions[basis_function_index[dimension].Get()];
+
+        // for 0th derivative query, we let's call eval directly.
+        if (derivative[current_dimension] == Derivative{}) {
+            basis_function_derivative_value *= basis_function(
+                parametric_coordinate[current_dimension],
+                unique_evaluations[current_dimension],
+                basis_function_index_without_offset[dimension].Get(),
+                tolerance
+            );
+
+        } else {
+            basis_function_derivative_value *= basis_function(
+                parametric_coordinate[current_dimension],
+                derivative[current_dimension],
+                unique_derivatives[current_dimension],
+                unique_evaluations[current_dimension],
+                top_level_computed[current_dimension],
+                basis_function_index_without_offset[dimension].Get(),
+                tolerance
+            );
+        }
+      }
+  );
   return basis_function_derivative_value;
 }
 

--- a/Sources/ParameterSpaces/parameter_space.inc
+++ b/Sources/ParameterSpaces/parameter_space.inc
@@ -358,16 +358,44 @@ void ParameterSpace<parametric_dimensionality>::CopyKnotVectors(KnotVectors_ con
 }
 
 template<int parametric_dimensionality>
-void ParameterSpace<parametric_dimensionality>::RecreateBasisFunctions(Tolerance const &tolerance) {
-  Dimension::ForEach(0, parametric_dimensionality, [&] (Dimension const &dimension) {
-      Dimension::Type_ const &current_dimension = dimension.Get();
-      Length::Type_ const number_of_basis_functions{GetNumberOfBasisFunctions(dimension).Get()};
-      typename BSplineBasisFunctions_::value_type &basis_functions = basis_functions_[current_dimension];
-      basis_functions.clear();
-      basis_functions.reserve(number_of_basis_functions);
-      KnotSpan::ForEach(0, number_of_basis_functions, [&] (KnotSpan const &start_of_support) {
-          basis_functions.emplace_back(BSplineBasisFunction::CreateDynamic(*knot_vectors_[current_dimension],
-                                           start_of_support, degrees_[current_dimension], tolerance)); }); });
+void ParameterSpace<parametric_dimensionality>::RecreateBasisFunctions(
+    Tolerance const &tolerance) {
+
+  Dimension::ForEach(
+      0,
+      parametric_dimensionality,
+      [&] (Dimension const &dimension) {
+          Dimension::Type_ const &current_dimension = dimension.Get();
+          Length::Type_ const number_of_basis_functions{
+              GetNumberOfBasisFunctions(dimension).Get()};
+          // basis and unique basis functions of current dimension
+          typename BSplineBasisFunctions_::value_type &basis_functions =
+              basis_functions_[current_dimension];
+          auto &unique_basis_functions =
+              unique_basis_functions_[current_dimension];
+
+          // clear existing
+          basis_functions.clear();
+          basis_functions.reserve(number_of_basis_functions);
+          unique_basis_functions.clear();
+
+          KnotSpan::ForEach(
+              0,
+              number_of_basis_functions,
+              [&] (KnotSpan const &start_of_support) {
+                  basis_functions.emplace_back(
+                      BSplineBasisFunction::CreateDynamic(
+                          *knot_vectors_[current_dimension],
+                          start_of_support,
+                          degrees_[current_dimension],
+                          unique_basis_functions,
+                          tolerance
+                      ) /* BSplineBasisFunction::CreateDynamic() */
+                  ); /* basis_functions.emplace_back() */
+              } /* [&] (KnotSpan&) */
+          ); /* KnotSpan::ForEach() */
+      } /* [&] (Dimension&) */
+  ); /* Dimension::ForEach() */
 }
 
 template<int parametric_dimensionality>

--- a/Sources/ParameterSpaces/zero_degree_b_spline_basis_function.cpp
+++ b/Sources/ParameterSpaces/zero_degree_b_spline_basis_function.cpp
@@ -57,6 +57,18 @@ ZeroDegreeBSplineBasisFunction::operator()(ParametricCoordinate const &parametri
 }
 
 ZeroDegreeBSplineBasisFunction::Type_
+ZeroDegreeBSplineBasisFunction::operator()(
+    ParametricCoordinate const &parametric_coordinate,
+    UniqueEvaluations& unique_evaluations,
+    int const &tree_info,
+    Tolerance const &tolerance) const {
+
+  // At each Spline evaluation, this function will be called exactly 4 times
+  // per dim. So, let's just compute. It is also generally faster 
+  return operator()(parametric_coordinate, tolerance);
+}
+
+ZeroDegreeBSplineBasisFunction::Type_
 ZeroDegreeBSplineBasisFunction::operator()(ParametricCoordinate const &parametric_coordinate,
                                            Derivative const &derivative, Tolerance const &tolerance) const {
 #ifndef NDEBUG
@@ -67,6 +79,32 @@ ZeroDegreeBSplineBasisFunction::operator()(ParametricCoordinate const &parametri
   }
 #endif
   return (derivative == Derivative{} ? operator()(parametric_coordinate, tolerance) : Type_{});
+}
+
+ZeroDegreeBSplineBasisFunction::Type_
+ZeroDegreeBSplineBasisFunction::operator()(
+    ParametricCoordinate const &parametric_coordinate,
+    Derivative const &derivative,
+    UniqueDerivatives& unique_derivatives,
+    UniqueEvaluations& unique_evaluations,
+    IsTopLevelComputed& top_level_computed,
+    int const &tree_info,
+    Tolerance const &tolerance) const {
+#ifndef NDEBUG
+  try {
+    utilities::numeric_operations::ThrowIfToleranceIsNegative(tolerance);
+  } catch (InvalidArgument const &exception) {
+    Throw(exception, "splinelib::sources::parameter_spaces::ZeroDegreeBSplineBasisFunction::operator()");
+  }
+#endif
+  if (derivative == Derivative{}) {
+    return operator()(parametric_coordinate,
+                      unique_derivatives,
+                      tree_info,
+                      tolerance);
+  } else {
+    return Type_{};
+  }
 }
 
 }  // namespace splinelib::sources::parameter_spaces

--- a/Sources/ParameterSpaces/zero_degree_b_spline_basis_function.hpp
+++ b/Sources/ParameterSpaces/zero_degree_b_spline_basis_function.hpp
@@ -51,9 +51,21 @@ class ZeroDegreeBSplineBasisFunction : public virtual BSplineBasisFunction {
   // Comparison based on numeric_operations::GetEpsilon<Tolerance>().
   friend bool operator==(ZeroDegreeBSplineBasisFunction const &lhs, ZeroDegreeBSplineBasisFunction const &rhs);
 
-  Type_ operator()(ParametricCoordinate const &parametric_coordinate, Tolerance const &tolerance = kEpsilon) const
-      override;
-  Type_ operator()(ParametricCoordinate const &parametric_coordinate, Derivative const &derivative,
+  Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                   Tolerance const &tolerance = kEpsilon) const override;
+  Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                   UniqueEvaluations& unique_evaluations,
+                   int const &tree_info,
+                   Tolerance const &tolerance = kEpsilon) const override;
+  Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                   Derivative const &derivative,
+                   Tolerance const &tolerance = kEpsilon) const override;
+  Type_ operator()(ParametricCoordinate const &parametric_coordinate,
+                   Derivative const &derivative,
+                   UniqueDerivatives& unique_derivatives,
+                   UniqueEvaluations& unique_evaluations,
+                   IsTopLevelComputed& top_level_computed,
+                   int const &tree_info,
                    Tolerance const &tolerance = kEpsilon) const override;
 };
 

--- a/Sources/Splines/b_spline.hpp
+++ b/Sources/Splines/b_spline.hpp
@@ -72,10 +72,22 @@ class BSpline : public Spline<parametric_dimensionality, dimensionality> {
                                                                  Tolerance const &tolerance);
   // Comparison based on numeric_operations::GetEpsilon<Tolerance>().
   friend bool operator==<parametric_dimensionality, dimensionality>(BSpline const &lhs, BSpline const &rhs);
-  Coordinate_ operator()(ParametricCoordinate_ const &parametric_coordinate, Tolerance const &tolerance = kEpsilon)
-      const override;
-  Coordinate_ operator()(ParametricCoordinate_ const &parametric_coordinate, Derivative_ const &derivative,
+  // Default evaluation uses lookup tricks
+  Coordinate_ operator()(ParametricCoordinate_ const &parametric_coordinate,
                          Tolerance const &tolerance = kEpsilon) const override;
+  Coordinate_ operator()(ParametricCoordinate_ const &parametric_coordinate,
+                         Derivative_ const &derivative,
+                         Tolerance const &tolerance = kEpsilon) const override;
+
+  // Original implementation of SplineLib
+  Coordinate_ FullyRecursiveEvaluate(
+      ParametricCoordinate_ const &parametric_coordinate,
+      Tolerance const &tolerance = kEpsilon) const;
+  Coordinate_ FullyRecursiveDerivative(
+      ParametricCoordinate_ const &parametric_coordinate,
+      Derivative_ const &derivative,
+      Tolerance const &tolerance = kEpsilon) const;
+
 
   void InsertKnot(Dimension const &dimension, Knot_ knot, Multiplicity const &multiplicity = kMultiplicity,
                   Tolerance const &tolerance = kEpsilon) const override;

--- a/Sources/Splines/b_spline.inc
+++ b/Sources/Splines/b_spline.inc
@@ -63,8 +63,141 @@ bool operator==(BSpline<parametric_dimensionality, dimensionality> const &lhs,
 
 template<int parametric_dimensionality, int dimensionality>
 typename Spline<parametric_dimensionality, dimensionality>::Coordinate_
-BSpline<parametric_dimensionality, dimensionality>::operator()(ParametricCoordinate_ const &parametric_coordinate,
-                                                               Tolerance const &tolerance) const {
+BSpline<parametric_dimensionality, dimensionality>::operator()(
+    ParametricCoordinate_ const &parametric_coordinate,
+    Tolerance const &tolerance) const {
+#ifndef NDEBUG
+  try {
+    utilities::numeric_operations::ThrowIfToleranceIsNegative(tolerance);
+  } catch (InvalidArgument const &exception) { Throw(exception, "splinelib::sources::splines::BSpline::operator()"); }
+#endif
+  ParameterSpace_ const &parameter_space = *Base_::parameter_space_;
+  const auto& degrees = parameter_space.GetDegrees();
+  Coordinate_ evaluated_b_spline{};
+
+  // prepare vectors to hold unique evaluation values.
+  typename ParameterSpace_::UniqueEvaluations_ unique_evaluations;
+
+  for (int i{}; i < parametric_dimensionality; ++i) {
+    // For `left->lookup & right->compute` to work, we should visit each
+    // node only once with depth-first method. If it has been visited already,
+    // we have to look it up.
+    // At the next loop, top-level nodes are visited multiple times. Thus,
+    // this should ensure that revisit is always a lookup.
+    //
+    // entry hints:
+    //   0 : zero-th degree evaluations  <- currently not used
+    //   1 : first degree evaluation
+    //   ...
+    //   degree + 0 : top-level evaluation, 0th support
+    //   ...
+    //   degree + degree : top-level evaluation, last support
+    auto& unique_evaluation = unique_evaluations[i];
+    unique_evaluation.assign(degrees[i] * 2 + 1, -1.0);
+  }
+  for (Index_ non_zero_basis_function{parameter_space.First()};
+       non_zero_basis_function != parameter_space.Behind();
+       ++non_zero_basis_function) {
+
+    Index_ const &basis_function =
+        (parameter_space.FindFirstNonZeroBasisFunction(parametric_coordinate)
+         + non_zero_basis_function.GetIndex());
+
+    utilities::std_container_operations::AddAndAssignToFirst(
+        evaluated_b_spline,
+        utilities::std_container_operations::Multiply(
+            (*vector_space_)[basis_function.GetIndex1d()],
+            // non_zero_basis_function will provide entry id (tree_info) for
+            // top-level node evaluations.
+            parameter_space.EvaluateBasisFunction(basis_function,
+                                                  non_zero_basis_function,
+                                                  parametric_coordinate,
+                                                  unique_evaluations)
+        )
+    );
+  }
+  return evaluated_b_spline;
+}
+
+template<int parametric_dimensionality, int dimensionality>
+typename Spline<parametric_dimensionality, dimensionality>::Coordinate_
+BSpline<parametric_dimensionality, dimensionality>::operator()(
+    ParametricCoordinate_ const &parametric_coordinate,
+    Derivative_ const &derivative,
+    Tolerance const &tolerance) const {
+#ifndef NDEBUG
+  try {
+    utilities::numeric_operations::ThrowIfToleranceIsNegative(tolerance);
+  } catch (InvalidArgument const &exception) { Throw(exception, "splinelib::sources::splines::BSpline::operator()"); }
+#endif
+  ParameterSpace_ const &parameter_space = *Base_::parameter_space_;
+  const auto& degrees = parameter_space.GetDegrees();
+  Coordinate_ evaluated_b_spline_derivative{};
+
+  // prepare map to hold unique evaluation values.
+  typename ParameterSpace_::UniqueDerivatives_ unique_derivatives;
+  typename ParameterSpace_::UniqueEvaluations_ unique_evaluations;
+  typename ParameterSpace_::IsTopLevelComputed_ top_levels_computed;
+
+  // Assign spaces for lookup. Similar procedure to evaluation.
+  for (int i{}; i < parametric_dimensionality; ++i) {
+    auto const &current_degree = degrees[i].Get();
+
+    // entry hints:
+    //   0 : zero-th degree derivative
+    //   1 : first degree derivative
+    //   ...
+    //   derivative + 0 : top-level derivative, 0th support
+    //   ...
+    //   derivative + degree : top-level derivative, last support
+    auto& unique_derivative = unique_derivatives[i];
+    unique_derivative.assign(derivative[i].Get() + current_degree + 1, 0.0);
+
+    // may not use all the slots, but this guarantees enough space.
+    // (current_degree - derivative[i]) would be an option, but this becomes
+    // negative for allowed but unreasonable derivative queries.
+    // TODO maybe return zero right away?
+    auto& unique_evaluation = unique_evaluations[i];
+    unique_evaluation.assign(current_degree * 2 + 1, -1.0);
+
+    // number of support is degree + 1
+    auto& top_level_computed = top_levels_computed[i];
+    top_level_computed.assign(current_degree + 1, false);
+  }
+
+  for (Index_ non_zero_basis_function{parameter_space.First()};
+       non_zero_basis_function != parameter_space.Behind();
+       ++non_zero_basis_function) {
+    Index_ const &basis_function = 
+        parameter_space.FindFirstNonZeroBasisFunction(parametric_coordinate)
+        + non_zero_basis_function.GetIndex();
+
+    utilities::std_container_operations::AddAndAssignToFirst(
+        evaluated_b_spline_derivative,
+        utilities::std_container_operations::Multiply(
+            ((*vector_space_))[basis_function.GetIndex1d()],
+            parameter_space.EvaluateBasisFunctionDerivative(
+                basis_function,
+                non_zero_basis_function,
+                top_levels_computed,
+                parametric_coordinate,
+                derivative,
+                unique_derivatives,
+                unique_evaluations,
+                tolerance
+            )
+        )
+    );
+  }
+
+  return evaluated_b_spline_derivative;
+}
+
+template<int parametric_dimensionality, int dimensionality>
+typename Spline<parametric_dimensionality, dimensionality>::Coordinate_
+BSpline<parametric_dimensionality, dimensionality>::FullyRecursiveEvaluate(
+    ParametricCoordinate_ const &parametric_coordinate,
+    Tolerance const &tolerance) const {
 #ifndef NDEBUG
   try {
     utilities::numeric_operations::ThrowIfToleranceIsNegative(tolerance);
@@ -85,7 +218,9 @@ BSpline<parametric_dimensionality, dimensionality>::operator()(ParametricCoordin
 
 template<int parametric_dimensionality, int dimensionality>
 typename Spline<parametric_dimensionality, dimensionality>::Coordinate_
-BSpline<parametric_dimensionality, dimensionality>::operator()(ParametricCoordinate_ const &parametric_coordinate,
+BSpline<parametric_dimensionality,
+        dimensionality>::FullyRecursiveDerivative(
+    ParametricCoordinate_ const &parametric_coordinate,
     Derivative_ const &derivative, Tolerance const &tolerance) const {
 #ifndef NDEBUG
   try {

--- a/Sources/Utilities/std_container_operations.hpp
+++ b/Sources/Utilities/std_container_operations.hpp
@@ -26,6 +26,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #include <tuple>
 #include <type_traits>
 #include <vector>
+#include <unordered_map>
 
 #include "Sources/Utilities/error_handling.hpp"
 #include "Sources/Utilities/named_type.hpp"
@@ -42,6 +43,8 @@ template<typename ...Types>
 using Tuple = std::tuple<Types...>;
 template<typename Type>
 using Vector = std::vector<Type>;
+template<typename KeyType, typename ValueType>
+using UnorderedMap = std::unordered_map<KeyType, ValueType>;
 
 }  // namespace splinelib
 


### PR DESCRIPTION
# Overview
High order (10+) splines were consuming way too much memory and evaluation evaluation was taking way too long. This PR tries to consume less memory and accelerate evaluations.

## Summary
- Create only unique basis functions. Duplicating ones have gets a copy of shared pointer.
- Avoid multiple visits of tree node during Evaluation, Derivative through lookup

## Note
Lookup evaluation starts to be faster than fully recursive evaluation from a certain (usually 4) degree.