### PR TITLE
add RemoveOneParametricDimension

### DIFF
--- a/Sources/ParameterSpaces/parameter_space.hpp
+++ b/Sources/ParameterSpaces/parameter_space.hpp
@@ -253,6 +253,9 @@ public:
   // Number of non-zero basis functions is equal to p+1 - see NURBS book P2.2.
   NumberOfBasisFunctions_ GetNumberOfNonZeroBasisFunctions() const;
 
+  virtual SharedPointer<ParameterSpace<parametric_dimensionality - 1>>
+  RemoveOneParametricDimension(const int parametric_dimension) const;
+
   virtual Index_ FindFirstNonZeroBasisFunction(
       ParametricCoordinate_ const& parametric_coordinate,
       Tolerance const& tolerance = kEpsilon) const;
@@ -294,17 +297,20 @@ public:
              Knot_ knot,
              Multiplicity const& multiplicity = kMultiplicity,
              Tolerance const& tolerance = kEpsilon);
+
   // Tries to interpret knot removal as the inverse process of knot insertion.
   virtual InsertionInformation_
   RemoveKnot(Dimension const& dimension,
              Knot_ const& knot,
              Multiplicity const& multiplicity = kMultiplicity,
              Tolerance const& tolerance = kEpsilon);
+
   // Elevation information refer to degree elevation of Bezier basis functions.
   virtual ElevationInformation_
   ElevateDegree(Dimension const& dimension,
                 Multiplicity const& multiplicity = kMultiplicity,
                 Tolerance const& tolerance = kEpsilon);
+
   // Tries to interpret degree reduction as the inverse process of degree
   // elevation.
   virtual ElevationInformation_
@@ -332,6 +338,14 @@ public:
   }
   virtual const UniqueBSplineBasisFunctions_&
   GetUniqueBSplineBasisFunctions() const {
+    return unique_basis_functions_;
+  }
+  virtual KnotVectors_& GetKnotVectors() { return knot_vectors_; }
+  virtual Degrees_& GetDegrees() { return degrees_; }
+  virtual BSplineBasisFunctions_& GetBSplineBasisFunctions() {
+    return basis_functions_;
+  }
+  virtual UniqueBSplineBasisFunctions_& GetUniqueBSplineBasisFunctions() {
     return unique_basis_functions_;
   }
 

--- a/Sources/ParameterSpaces/parameter_space.inc
+++ b/Sources/ParameterSpaces/parameter_space.inc
@@ -171,6 +171,38 @@ int ParameterSpace<parametric_dimensionality>::GetTotalNumberOfBasisFunctions()
 }
 
 template<int parametric_dimensionality>
+SharedPointer<ParameterSpace<parametric_dimensionality - 1>>
+ParameterSpace<parametric_dimensionality>::RemoveOneParametricDimension(
+    const int parametric_dimension) const {
+  if constexpr (parametric_dimensionality < 2) {
+    return nullptr;
+  } else {
+    // prepare output
+    auto out_pspace =
+        std::make_shared<ParameterSpace<parametric_dimensionality - 1>>();
+
+    auto& out_degrees = out_pspace->GetDegrees();
+    auto& out_knot_vectors = out_pspace->GetKnotVectors();
+    auto& out_basis = out_pspace->GetBSplineBasisFunctions();
+    auto& out_unique_basis = out_pspace->GetUniqueBSplineBasisFunctions();
+
+    int out_dim_id{};
+    for (int i{}; i < parametric_dimensionality; ++i) {
+      if (i == parametric_dimension) {
+        continue;
+      }
+      out_degrees[out_dim_id] = degrees_[i];
+      out_knot_vectors[out_dim_id] = knot_vectors_[i];
+      out_basis[out_dim_id] = basis_functions_[i];
+      out_unique_basis[out_dim_id] = unique_basis_functions_[i];
+      ++out_dim_id;
+    }
+
+    return out_pspace;
+  }
+}
+
+template<int parametric_dimensionality>
 typename ParameterSpace<parametric_dimensionality>::Index_
 ParameterSpace<parametric_dimensionality>::FindFirstNonZeroBasisFunction(
     ParametricCoordinate_ const& parametric_coordinate,

--- a/Sources/Utilities/math_operations.cpp
+++ b/Sources/Utilities/math_operations.cpp
@@ -19,7 +19,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "Sources/Utilities/math_operations.hpp"
 
-//#include <cmath> // NOLINT(whitespace/comments)
+// #include <cmath> // NOLINT(whitespace/comments)
 
 #include "Sources/Utilities/error_handling.hpp"
 

--- a/Sources/Utilities/string_operations.hpp
+++ b/Sources/Utilities/string_operations.hpp
@@ -22,7 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include <algorithm>
 // NOLINTNEXTLINE(whitespace/comments)
-//#include <format>  // TODO(all): C++20 library providing std::format to
+// #include <format>  // TODO(all): C++20 library providing std::format to
 // replace Write (not yet implemented).
 #include <functional>
 #include <iterator>


### PR DESCRIPTION
adds a function to create a parameter space without a specified dimension. useful for creating boundary spline. you can skip a lot of `RecreateBasisFunctions`. 