### PR TITLE
less reallocation for coordinate inserts

### DIFF
--- a/Sources/BSplineLib/ParameterSpaces/knot_vector.cpp
+++ b/Sources/BSplineLib/ParameterSpaces/knot_vector.cpp
@@ -306,7 +306,7 @@ void KnotVector::Insert(Knot knot,
   }
 #endif
   knots_.insert(knots_.begin() + FindSpan(knot, tolerance).Get() + 1,
-                multiplicity.Get(),
+                multiplicity,
                 std::move(knot));
 }
 
@@ -325,8 +325,8 @@ Multiplicity KnotVector::Remove(Knot const& knot,
     Throw(exception, kName);
   }
 #endif
-  if (Multiplicity::Type_ const number_of_removals{
-          std::min(multiplicity, DetermineMultiplicity(knot, tolerance)).Get()};
+  if (Multiplicity const number_of_removals{
+          std::min(multiplicity, DetermineMultiplicity(knot, tolerance))};
       number_of_removals != 0) {
     KnotSpan const& knot_span = FindSpan(knot, tolerance);
     if (DoesParametricCoordinateEqualBack(knot, tolerance)) {
@@ -336,7 +336,7 @@ Multiplicity KnotVector::Remove(Knot const& knot,
       ConstIterator_ const& first_knot = (knots_.begin() + knot_span.Get());
       knots_.erase(first_knot - (number_of_removals - 1), first_knot + 1);
     }
-    return Multiplicity{number_of_removals};
+    return number_of_removals;
   } else {
     return Multiplicity{};
   }

--- a/Sources/BSplineLib/ParameterSpaces/parameter_space.hpp
+++ b/Sources/BSplineLib/ParameterSpaces/parameter_space.hpp
@@ -296,8 +296,6 @@ protected:
   Degrees_ degrees_;
 
 private:
-  using MultiplicityType_ = Multiplicity::Type_;
-
   void CopyKnotVectors(KnotVectors_ const& knot_vectors);
 
   // Number of non-zero basis functions is equal to p+1 - see NURBS book P2.2.

--- a/Sources/BSplineLib/Splines/b_spline.hpp
+++ b/Sources/BSplineLib/Splines/b_spline.hpp
@@ -21,6 +21,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #define SOURCES_SPLINES_B_SPLINE_HPP_
 
 #include <algorithm>
+#include <iostream>
 #include <iterator>
 #include <utility>
 

--- a/Sources/BSplineLib/Splines/b_spline.inl
+++ b/Sources/BSplineLib/Splines/b_spline.inl
@@ -234,11 +234,11 @@ Multiplicity BSpline<para_dim>::RemoveKnot(Dimension const& dimension,
       parameter_space.GetNumberOfBasisFunctions()};
   auto const& [start_value, coefficients] =
       parameter_space.RemoveKnot(dimension, knot, multiplicity, tolerance);
-  Multiplicity::Type_ const& removals = coefficients.size();
+  Multiplicity const& removals = coefficients.size();
   for (Multiplicity removal{removals}; removal > Multiplicity{}; --removal) {
     VectorSpace_& vector_space = *vector_space_;
     VectorSpace_ const vector_space_backup{vector_space};
-    KnotRatios_ const& current_coefficients = coefficients[removal.Get() - 1];
+    KnotRatios_ const& current_coefficients = coefficients[removal - 1];
     IndexLength_ number_of_coordinates_in_slice{number_of_coordinates};
     number_of_coordinates_in_slice[dimension] = Length{};
     IndexLength_ const previous_number_of_coordinates{number_of_coordinates};
@@ -333,7 +333,7 @@ void BSpline<para_dim>::ElevateDegree(Dimension const& dimension,
   for (int segment{}; segment < number_of_segments; ++segment) {
     int interior_coordinate{maximum_interior_coordinate},
         last_coordinate{((segment + 1) * last_segment_coordinate)
-                        + (segment * multiplicity.Get())};
+                        + (segment * multiplicity)};
     for (; interior_coordinate >= (last_segment_coordinate - 1);
          --interior_coordinate) {
       BinomialRatios_ const& current_coefficients =

--- a/Sources/BSplineLib/Splines/b_spline.inl
+++ b/Sources/BSplineLib/Splines/b_spline.inl
@@ -159,8 +159,7 @@ void BSpline<para_dim>::InsertKnot(Dimension const& dimension,
       parameter_space.InsertKnot(dimension, knot, multiplicity, tolerance);
   // TODO(all): use std::for_each once clang supports capturing of variables
   // from structured bindings
-  const int n_new_points =
-      coefficients.size() * (n_coords_per_slice * multiplicity);
+  const int n_new_points = coefficients.size() * n_coords_per_slice;
   vector_space.AppendEmptyCoordinates(n_new_points);
   int ignore_from{};
   for (KnotRatios_ const& current_coefficients : coefficients) {
@@ -328,7 +327,7 @@ void BSpline<para_dim>::ElevateDegree(Dimension const& dimension,
       static_cast<int>(coefficients.size() - 1)};
   int ignore_from{};
   vector_space.AppendEmptyCoordinates(
-      (n_coords_per_slice * multiplicity) * number_of_segments
+      n_coords_per_slice * number_of_segments
       * (maximum_interior_coordinate - (last_segment_coordinate - 1) + 1));
   for (int segment{}; segment < number_of_segments; ++segment) {
     int interior_coordinate{maximum_interior_coordinate},

--- a/Sources/BSplineLib/Splines/b_spline.inl
+++ b/Sources/BSplineLib/Splines/b_spline.inl
@@ -179,11 +179,13 @@ void BSpline<para_dim>::InsertKnot(Dimension const& dimension,
       Index const insertion_position = coordinate.GetIndex1d();
       // C^0 to C^-1 insertion, second case does not apply (insert repetition)
       if (current_coefficients.empty()) {
+        // we need to pass copy to this
         vector_space.StaticInsert(
-            coordinate.GetIndex1d(),
+            insertion_position,
             vector_space[Index_::GetIndex1d(previous_number_of_coordinates,
                                             coordinate_value)
-                         + slice_coordinate.GetIndex1d()],
+                         + slice_coordinate.GetIndex1d()]
+                .Copy(),
             n_total_original_coords + ignore_from++);
         continue;
       }

--- a/Sources/BSplineLib/Utilities/containers.hpp
+++ b/Sources/BSplineLib/Utilities/containers.hpp
@@ -561,6 +561,15 @@ public:
     return *this;
   }
 
+  /// @brief this[i] = a[i]
+  /// @param a
+  /// @return
+  constexpr Data Copy() const {
+    assert(data_);
+
+    return Data(*this);
+  }
+
   /// @brief copies from a and this will own the data
   /// @param a
   /// @return

--- a/Sources/BSplineLib/Utilities/named_type.hpp
+++ b/Sources/BSplineLib/Utilities/named_type.hpp
@@ -243,7 +243,7 @@ using IntType__ = int;
 using Degree = IntType__;
 using Derivative = IntType__;
 using KnotSpan = utilities::NamedType<struct KnotSpanName, int>;
-using Multiplicity = utilities::NamedType<struct MultiplicityName, int>;
+using Multiplicity = IntType__;
 using ParametricCoordinate = RealType__;
 //    utilities::NamedType<struct ParametricCoordinateName, double>;
 

--- a/Sources/BSplineLib/VectorSpaces/vector_space.cpp
+++ b/Sources/BSplineLib/VectorSpaces/vector_space.cpp
@@ -23,13 +23,15 @@ namespace bsplinelib::vector_spaces {
 
 void VectorSpace::AppendEmptyCoordinates(const int n) {
   const auto& shape = coordinates_.Shape();
-  const auto& n_coord = shape[0];
-  const auto& dim = shape[1];
+  const auto n_coord = shape[0];
+  const auto dim = shape[1];
 
   Coordinates_ new_coordinates(n_coord + n, dim);
 
   // copy all the elements
-  std::copy_n(coordinates_.begin(), n_coord * dim, new_coordinates.begin());
+  std::copy_n(coordinates_.begin(),
+              coordinates_.size(),
+              new_coordinates.begin());
 
   // move assign new coords as coords
   coordinates_ = std::move(new_coordinates);
@@ -41,8 +43,8 @@ void VectorSpace::StaticInsert(int const& coordinate_index,
 
   // size info
   const auto& shape = coordinates_.Shape();
-  const auto& n_coord = shape[0];
-  const auto& dim = shape[1];
+  const auto n_coord = shape[0];
+  const auto dim = shape[1];
 
   // runtime index checks
   // first, wrap id
@@ -70,13 +72,18 @@ void VectorSpace::StaticInsert(int const& coordinate_index,
   if (ignore_elements_from > coordinate_index) {
     // shift one coordinate
     // copy contents after index first, but backwards to avoid overlap
+    // just make sure coordinate is not partial view of the coordinate_. if so,
+    // copy!
+    auto* source_end = &coordinates_(ignore_elements_from, 0);
     std::copy_backward(&coordinates_(coordinate_index, 0),
-                       &coordinates_(ignore_elements_from, 0),
-                       coordinates_.begin() + ((ignore_elements_from + 1) * dim));
+                       source_end,
+                       source_end + dim);
   }
 
   // copy at index
-  std::copy_n(coordinate.begin(), dim, &coordinates_(coordinate_index, 0));
+  std::copy_n(coordinate.begin(),
+              coordinate.size(),
+              &coordinates_(coordinate_index, 0));
 }
 
 void VectorSpace::Replace(int const& coordinate_index,

--- a/Sources/BSplineLib/VectorSpaces/vector_space.hpp
+++ b/Sources/BSplineLib/VectorSpaces/vector_space.hpp
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include <algorithm>
 #include <functional>
+#include <iostream>
 #include <utility>
 
 #include "BSplineLib/Utilities/containers.hpp"
@@ -123,6 +124,29 @@ public:
   /// @brief shape[0] of coordinates array
   /// @return
   virtual int GetNumberOfCoordinates() const { return coordinates_.Shape()[0]; }
+
+  /// @brief Appends empty (not initialized) coordinates. Similar use case as
+  /// vector::reserve(), instead, it will change the size right away. You can
+  /// use in combination with Insert() to replace ReallocateInsert()
+  /// @param n
+  virtual void AppendEmptyCoordinates(const int n);
+
+  /// @brief Similar use case as vector::reserve() then vector::insert(),
+  /// instead we work only with size (without the concept of capacity).
+  ///
+  /// Inserts a coordinate at given index. Static, in a sense that this
+  /// won't reallocate space. That means, values of at least one coordinate will
+  /// be lost. Specify ignore_elements_from to hint number of coordinates to
+  /// keep. This value is used for runtime size check and reduce unnecessary
+  /// copies. Use with AppendEmptyCoordinates
+  ///
+  /// @param coordinate_index
+  /// @param coordinate
+  /// @param ignore_elements_from takes python style negative indexing. However,
+  /// up to one cycle.
+  virtual void StaticInsert(int const& coordinate_index,
+                            const Coordinate_& coordinate,
+                            int ignore_elements_from = -1);
 
   /// @brief Replace coordinate value
   /// @param coordinate_index

--- a/Sources/BSplineLib/VectorSpaces/vector_space.hpp
+++ b/Sources/BSplineLib/VectorSpaces/vector_space.hpp
@@ -139,6 +139,7 @@ public:
   /// be lost. Specify ignore_elements_from to hint number of coordinates to
   /// keep. This value is used for runtime size check and reduce unnecessary
   /// copies. Use with AppendEmptyCoordinates
+  /// Make sure coordinate is not partial view of the coordinate_. If so, copy!
   ///
   /// @param coordinate_index
   /// @param coordinate


### PR DESCRIPTION
- Removes multiplicity NamedType
- during knot insertion / degree elevation, reallocate space once and insert without reallocating. This is done with combination of `AppendEmptyCoordinates(n_coords)` + `StaticInsert(index, new_coordinate, ignore_coordinates_from)`, where `ignore_coordinates_from` is a hint variable to mark relevant number of coordinates  (reduces number of unnecessary copies).
- tested/integrated in tataratat/splinepy#428